### PR TITLE
update the range of mknd:context in mekanoid.ttl

### DIFF
--- a/ontologies/mekanoid/mekanoid.ttl
+++ b/ontologies/mekanoid/mekanoid.ttl
@@ -82,8 +82,8 @@ sh:targetClass rdf:type owl:AnnotationProperty .
 :context rdf:type owl:AnnotationProperty ;
          rdfs:label "context"@en ;
          rdfs:subPropertyOf rdfs:comment ;
-         rdfs:range xsd:anyURI ,
-                    xsd:longString .
+         rdfs:range [ rdf:type owl:Class ; 
+                      owl:unionOf ( xsd:anyURI xsd:string ) ] .
 
 
 ###  https://schema.mekanoid.io/mekanoid.ttl#cpe


### PR DESCRIPTION
fixes #20 by using xsd:string and owl:unionOf

*  Removed the missing datatype xsd:longString from the range of :context.
*  Added the standard xsd:string datatype to the range of :context.
*  Used owl:unionOf as otherwise the RDFS inference will be an intersection (both) xsd:anyURI AND xsd:string. 